### PR TITLE
Make the enabled parameter of the unit configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "template_file" "ssh-key-agent" {
 }
 
 data "ignition_systemd_unit" "ssh-key-agent" {
-  name = "ssh-key-agent.service"
-
+  name    = "ssh-key-agent.service"
+  enabled = "${var.enabled}"
   content = "${data.template_file.ssh-key-agent.rendered}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "ssh_key_agent_version" {
   type        = "string"
   description = "The ssh-key-agent version"
 }
+
+variable "enabled" {
+  type        = "string"
+  default     = true
+  description = "Whether or not the service shall be enabled"
+}


### PR DESCRIPTION
This supports cases where people were using the old template + ignition unit with `enabled = false`.